### PR TITLE
Fix returned eventsource status code when not found

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -220,6 +220,7 @@ exports.eventsource = function eventsource(req, res) {
 
     res.header('Content-Type', 'text/event-stream');
     res.write('event: init\n');
+    res.write('retry: 10\n');
     res.write('data: ' + JSON.stringify({
             id: connection.id,
             url: build_absolute_url(req, '/eventsource/' + connection.id)

--- a/logic.js
+++ b/logic.js
@@ -190,7 +190,8 @@ exports.eventsource = function eventsource(req, res) {
         res.header('Access-Control-Allow-Origin', origin);
     }
     if (connection == null) {
-        return res.sendStatus(404);
+        // https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events-intro
+        return res.sendStatus(204);
     }
 
     res.header('Cache-Control', 'no-cache');

--- a/test/ngsiproxySpec.js
+++ b/test/ngsiproxySpec.js
@@ -94,13 +94,13 @@ describe('ngsi-proxy server', () => {
         });
     });
 
-    it('404 when trying to connect to an inexistent eventsource', (done) => {
+    it('204 when trying to connect to an inexistent eventsource', (done) => {
         request.get('http://localhost:4321/eventsource/6d3ab640-345c-11e8-aee8-4fe128ae5aa3', (error, response, body) => {
             expect(error).toBe(null);
             expect(response.headers['access-control-allow-origin']).toBe(undefined);
             expect(response.headers['access-control-allow-headers']).toBe(undefined);
             expect(response.headers['access-control-expose-headers']).toBe(undefined);
-            expect(response.statusCode).toBe(404);
+            expect(response.statusCode).toBe(204);
             done();
         });
     });


### PR DESCRIPTION
[Standard](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events-intro) states that the correct status code is 204 instead of the normal 404. 