### PR TITLE
Changes default and minimum reconnection timeout

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -42,11 +42,11 @@ const uuid = require('uuid/v1');
 
 let RECONNECTION_TIMEOUT = Number(process.env.RECONNECTION_TIMEOUT);
 if (Number.isNaN(RECONNECTION_TIMEOUT)) {
-    // Default value: 24h
-    RECONNECTION_TIMEOUT = 24 * 60 * 1000;
-} else if (RECONNECTION_TIMEOUT < 30000) {
-    // Minimun value: 30s
+    // Default value: 30s
     RECONNECTION_TIMEOUT = 30000;
+} else if (RECONNECTION_TIMEOUT < 5000) {
+    // Minimun value: 5s
+    RECONNECTION_TIMEOUT = 5000;
 }
 
 const connections = {};
@@ -306,7 +306,7 @@ exports.create_callback = function create_callback(req, res) {
 
     let buf = '';
     req.setEncoding('utf8');
-    req.on('data', function (chunck) { buf += chunck; });
+    req.on('data', function (chunk) { buf += chunk; });
     req.on('end', function () {
         buf = buf.trim();
 


### PR DESCRIPTION
Reduces the minimum reconnection timeout to 5 seconds, and the default one to 30 seconds.

24h (altough it actually was 24 minutes) is a lot when most clients will just connect for shorts spans of time, as that will prevent the context broker from realizing that it should delete the subscription if the client didn't manage to delete it itself (for example, when the browser crashes).

A much more reasonable default timeout is 30 seconds, with a minimum of 5 seconds.